### PR TITLE
fix(command): return keys in HMGET command correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes Logs
 
+## v3.0.3
+
+- fix(command): Return keys in `HMGET` command correctly.
+
 ## v3.0.2
 
 - fix(command): Incorrect preprocessing of arguments for `SREM` command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@litert/redis",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@litert/redis",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@litert/redis",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A redis protocol implement for Node.js.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/lib/Commands.ts
+++ b/src/lib/Commands.ts
@@ -1132,7 +1132,7 @@ export const COMMANDS: Record<keyof C.ICommandAPIs, ICommand> = {
         },
         process(data: Array<[number, Buffer]>, args: any[]): any {
 
-            return U.list2NullableStringDict(args[1], data);
+            return U.list2NullableStringDict(args.slice(1), data);
         }
     },
 
@@ -1163,7 +1163,7 @@ export const COMMANDS: Record<keyof C.ICommandAPIs, ICommand> = {
         },
         process(data: Array<[number, Buffer]>, args: any[]): any {
 
-            return U.list2NullableBufferDict(args[1], data);
+            return U.list2NullableBufferDict(args.slice(1), data);
         }
     },
 

--- a/src/test/commands/hash.ts
+++ b/src/test/commands/hash.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import * as Assert from 'node:assert';
+import { cmdCli } from '../common';
+
+const TEST_KEY_PREFIX = 'test_hash_';
+
+test('Command For Hashes', async (t) => {
+
+    await cmdCli.del([...await cmdCli.keys(`${TEST_KEY_PREFIX}*`), 'any']);
+
+    await t.test('Create a hash with one key', async () => {
+
+        Assert.strictEqual(await cmdCli.hSet(`${TEST_KEY_PREFIX}a`, 'key1', 'a'), true);
+        Assert.strictEqual(await cmdCli.hSet(`${TEST_KEY_PREFIX}b`, 'key1', 'b'), true);
+
+        Assert.ok(true);
+    });
+
+    await t.test('Get value of one key in a hash', async () => {
+
+        Assert.strictEqual(await cmdCli.hGet(`${TEST_KEY_PREFIX}a`, 'key1'), 'a');
+        Assert.strictEqual(await cmdCli.hGet(`${TEST_KEY_PREFIX}b`, 'key1'), 'b');
+    });
+
+    await t.test('Create a hash with multiple keys', async () => {
+
+        await cmdCli.hMSet(`${TEST_KEY_PREFIX}m1`, {
+            'k1': 'x',
+            'k2': 'y',
+            'k3': 'z'
+        });
+
+        Assert.ok(true);
+    });
+
+    await t.test('Get values of multiple keys in a hash', async () => {
+
+        Assert.deepStrictEqual(await cmdCli.hMGet(`${TEST_KEY_PREFIX}m1`, ['k1', 'k2']), {
+            'k1': 'x',
+            'k2': 'y',
+        });
+
+        Assert.deepStrictEqual(await cmdCli.hMGet$(`${TEST_KEY_PREFIX}m1`, ['k1', 'k2']), {
+            'k1': Buffer.from('x'),
+            'k2': Buffer.from('y'),
+        });
+
+        Assert.deepStrictEqual(await cmdCli.hMGet(`${TEST_KEY_PREFIX}m1`, ['k1', 'k2', 'k4']), {
+            'k1': 'x',
+            'k2': 'y',
+            'k4': null,
+        });
+
+        Assert.deepStrictEqual(await cmdCli.hMGet$(`${TEST_KEY_PREFIX}m1`, ['k1', 'k2', 'k4']), {
+            'k1': Buffer.from('x'),
+            'k2': Buffer.from('y'),
+            'k4': null,
+        });
+    });
+
+    await t.test('Get values of all keys in a hash', async () => {
+
+        Assert.deepStrictEqual(await cmdCli.hGetAll(`${TEST_KEY_PREFIX}m1`), {
+            'k1': 'x',
+            'k2': 'y',
+            'k3': 'z',
+        });
+    });
+});
+
+test.after(async () => {
+
+    await cmdCli.close();
+});


### PR DESCRIPTION
The wrapper of `HMGET` command read the keys from the arguments incorrectly