### PR TITLE
fix(protocol): decode "*-1" correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v3.0.3
 
 - fix(command): Return keys in `HMGET` command correctly.
+- fix(protocol): decode `*-1` correctly
 
 ## v3.0.2
 

--- a/src/lib/Decoder.ts
+++ b/src/lib/Decoder.ts
@@ -234,24 +234,32 @@ export class Decoder extends EventEmitter implements C.IDecoder {
 
                     if (end > -1) {
 
-                        this._ctx.type = C.EDataType.LIST;
-
-                        this._ctx.value = [];
-
                         this._ctx.data.length = parseInt(this._buf.subarray(
                             this._ctx.pos,
                             end
                         ).toString());
 
-                        if (this._ctx.data.length === 0 || this._ctx.data.length === -1) {
+                        if (this._ctx.data.length === -1) {
 
+                            this._ctx.type = C.EDataType.NULL;
+                            this._ctx.value = null;
                             this._pop(end + 2);
                         }
                         else {
 
-                            this._cut(end + 2);
-                            this._ctx.pos = this._cursor;
-                            this._ctx.status = EDecodeStatus.READING_LIST;
+                            this._ctx.type = C.EDataType.LIST;
+                            this._ctx.value = [];
+
+                            if (this._ctx.data.length === 0) {
+
+                                this._pop(end + 2);
+                            }
+                            else {
+
+                                this._cut(end + 2);
+                                this._ctx.pos = this._cursor;
+                                this._ctx.status = EDecodeStatus.READING_LIST;
+                            }
                         }
                     }
                     else {


### PR DESCRIPTION
Should decode `*-1\r\n` as a `nil`(`null`)