### PR TITLE
test(client): add regression test for void command promise rejection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v3.2.1
 
 - fix(client): missing returning the result of "_command()" caused uncaught promise.
+- test(client): added regression test for rejected promises from commands with `process: null`.
 
 ## v3.2.0
 

--- a/src/test/commands/string.ts
+++ b/src/test/commands/string.ts
@@ -52,6 +52,18 @@ test('Command For Strings', async (t) => {
 
         Assert.ok(true);
     });
+
+    await t.test('Errors from void commands should reject the returned promise', async () => {
+
+        await Assert.rejects(
+            cmdCli.rename('test_set_missing_source', 'test_set_missing_dest'),
+            (e: any) => {
+
+                Assert.strictEqual(e?.name, 'command_failure');
+                return true;
+            }
+        );
+    });
 });
 
 test.after(async () => {


### PR DESCRIPTION
## Summary

Adds a regression test for the recent client fix around commands with `process: null`.

## Changes

- added a test case for `CommandClient` void-style commands
- verified that a failing `rename` call rejects the returned promise

## Why

This ensures the promise rejection behavior is covered by tests and helps prevent the regression from coming back.
